### PR TITLE
Introduce dedicated html based email template 

### DIFF
--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -8,23 +8,26 @@
 <div id="email-body">
   <div id="person">Dear Max Mustermann,</div>
   <br>
-  <div id="content">this is an automated email to inform you about recent updates on your subscribed project
+  <div id="content">this is an automated email to inform you about recent updates on your subscribed
+    project
     <span id="project-information">My awesome project (ABCDE):</span>
     <br>
     <div id="sample-status-enumeration">
-      <div id="sample-status-failed-qc"><strong>X samples failed QC</strong>
-        <span id ="failed-qc-contact">(get in contact: <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>)</span>
+      <div id="sample-status-failed-qc"><strong><span id="sample-status-failed-qc-count">X</span>
+        samples failed QC</strong>
+        <span id="failed-qc-contact">(get in contact: <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>)</span>
       </div>
-      <div id="sample-status-available-data">X samples data available</div>
+      <div id="sample-status-available-data"><span id="sample-status-available-data-count">X</span>
+        samples have data available
+      </div>
     </div>
     <br>
-    </div>
-    <div id="subscription-information">Click <a href="https://portal.qbic.uni-tuebingen.de/portal/">here</a>
-      to learn more or unsubscribe from further notifications.
-    </div>
-    <br>
-    <div id="sign-off">Best regards, <br> your QBiC team.</div>
   </div>
+  <div id="subscription-information">Click <a href="https://portal.qbic.uni-tuebingen.de/portal/">here</a>
+    to learn more or unsubscribe from further notifications.
+  </div>
+  <br>
+  <div id="sign-off">Best regards, <br> your QBiC team.</div>
 </div>
 </body>
 </html>

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -3,28 +3,25 @@
 <head>
   <meta charset="UTF-8">
   <title>email-update-template</title>
-  <link rel="stylesheet" href="stylesheet.css">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 </head>
 <body>
 <div id="email-body">
   <div id="person">Dear Max Mustermann,</div>
   <br>
   <div id="content">this is an automated email to inform you about recent updates on your subscribed project
-    <div id = "project-information">My awesome project (ABCDE):</div>
+    <div id="project-information">My awesome project (ABCDE):</div>
     <br>
     <div id="sample-status-enumeration">
-      <div id = "sample-status-received-samples">X samples received</div>
-      <div id="sample-status-passed-qc"> X samples finished QC</div>
-      <div id="sample-status-failed-qc"><strong>X samples failed QC</strong></div>
-      <div id = "sample-status-finished-library-prep">X samples library prep finished</div>
+      <div id="sample-status-failed-qc"><strong>X samples failed QC</strong>
+        <span id ="failed-qc-contact">(get in contact: <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>)</span>
+      </div>
       <div id="sample-status-available-data">X samples data available</div>
     </div>
     <br>
-    <div id="detailed-information">Click <a href="Link to some explanation">here</a> to learn
-      more.</div>
-    <div id="unsubscribe-information">Click <a href="Link to subscription explanation">here</a>
-      to learn more or unsubscribe from further notifications.</div>
+    </div>
+    <div id="subscription-information">Click <a href="https://portal.qbic.uni-tuebingen.de/portal/">here</a>
+      to learn more or unsubscribe from further notifications.
+    </div>
     <br>
     <div id="sign-off">Best regards, <br> your QBiC team.</div>
   </div>

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -10,7 +10,7 @@
   <br>
   <div id="content">this is an automated email to inform you about recent updates on your subscribed
     project
-    <span id="project-information">My awesome project (ABCDE):</span>
+    <span id="project-information"><span id="project-title">My awesome project</span> (<span id="project-code">ABCDE</span>):</span>
     <br>
     <div id="sample-status-enumeration">
       <div id="sample-status-failed-qc"><strong><span id="sample-status-failed-qc-count">X</span>

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -9,7 +9,7 @@
   <div id="person">Dear Max Mustermann,</div>
   <br>
   <div id="content">this is an automated email to inform you about recent updates on your subscribed project
-    <div id="project-information">My awesome project (ABCDE):</div>
+    <span id="project-information">My awesome project (ABCDE):</span>
     <br>
     <div id="sample-status-enumeration">
       <div id="sample-status-failed-qc"><strong>X samples failed QC</strong>

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -7,26 +7,24 @@
 <body>
 <div id="email-body">
   <div id="introduction">Dear <span id="person-information">Max Mustermann</span></div>
-  <br>
-  <div id="content">this is an automated email to inform you about recent updates on your subscribed
-    project
-    <span id="project-information"><span id="project-title">My awesome project</span> (<span id="project-code">ABCDE</span>):</span>
-    <br>
-    <div id="sample-status-enumeration">
-      <div id="sample-status-failed-qc"><strong><span id="sample-status-failed-qc-count">X</span>
-        samples failed QC</strong>
-        <span id="failed-qc-contact">(get in contact: <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>)</span>
-      </div>
-      <div id="sample-status-available-data"><span id="sample-status-available-data-count">X</span>
-        samples have data available
-      </div>
+  <p id="content">this is an automated email to inform you about recent updates on your subscribed
+    project<br>
+    <span id="project-information"><span id="project-title">My awesome project</span> (<span
+        id="project-code">ABCDE</span>):</span>
+  <div id="sample-status-enumeration">
+    <div id="sample-status-failed-qc"><strong><span id="sample-status-failed-qc-count">X</span>
+      samples failed QC</strong>
+      <span id="failed-qc-contact">(get in contact: <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>)</span>
     </div>
-    <br>
+    <div id="sample-status-available-data"><span id="sample-status-available-data-count">X</span>
+      samples have data available
+    </div>
   </div>
-  <div id="subscription-information">Click <a href="https://portal.qbic.uni-tuebingen.de/portal/">here</a>
+  </p>
+  <p id="subscription-information">Click <a
+      href="https://portal.qbic.uni-tuebingen.de/portal/">here</a>
     to learn more or unsubscribe from further notifications.
-  </div>
-  <br>
+  </p>
   <div id="sign-off">Best regards, <br> your QBiC team.</div>
 </div>
 </body>

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <div id="email-body">
-  <div id="person">Dear Max Mustermann,</div>
+  <div id="introduction">Dear <span id="person-information">Max Mustermann</span></div>
   <br>
   <div id="content">this is an automated email to inform you about recent updates on your subscribed
     project

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>email-update-template</title>
+  <link rel="stylesheet" href="stylesheet.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+</head>
+<body>
+<div id="email-body">
+  <div id="person">Dear Max Mustermann,</div>
+  <br>
+  <div id="content">this is an automated email to inform you about recent updates on your subscribed project
+    <div id = "project-information">My awesome project (ABCDE):</div>
+    <br>
+    <div id="sample-status-enumeration">
+      <div id = "sample-status-received-samples">X samples received</div>
+      <div id="sample-status-passed-qc"> X samples finished QC</div>
+      <div id="sample-status-failed-qc"><strong>X samples failed QC</strong></div>
+      <div id = "sample-status-finished-library-prep">X samples library prep finished</div>
+      <div id="sample-status-available-data">X samples data available</div>
+    </div>
+    <br>
+    <div id="detailed-information">Click <a href="Link to some explanation">here</a> to learn
+      more.</div>
+    <div id="unsubscribe-information">Click <a href="Link to subscription explanation">here</a>
+      to learn more or unsubscribe from further notifications.</div>
+    <br>
+    <div id="sign-off">Best regards, <br> your QBiC team.</div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Addresses #9  

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked

**Description of changes**
Since we want to include custom styling(bold text and hyperlinks) simply sending a text-based email is not going to cut it anymore. Therefore we need a dedicated HTML template containing the requested email message. 
This template will be later filled via jsoup similiar to the offer pdf generation in tomato 🍅  

**Technical information**
The underlying process (mailutilx or sendmail) expect the file content to be piped as a an input. For this reason the most convienient solution is to have a dedicated html file. 
