### PR TITLE
E2.02/send html email

### DIFF
--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
@@ -71,7 +71,7 @@ class DependencyManager {
 
     private void setupSendEmail(){
         //ToDo Remove after testing since this will be provided by the use case
-        NotificationContent notificationContent = new NotificationContent.Builder("Jo", "My_Dude", "Jo.mydude@coolguy.de", "coolProject", "NICE1", 2, 1000).build()
+        NotificationContent notificationContent = new NotificationContent.Builder("Jo", "My_Dude", "steffen.greiner@uni-tuebingen.de", "coolProject", "NICE1", 2, 1000).build()
         emailGenerator = new EmailGenerator(notificationContent)
     }
 

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
@@ -2,10 +2,10 @@ package life.qbic.samplenotificator
 
 import groovy.util.logging.Log4j2
 import life.qbic.business.notification.create.CreateNotification
-import life.qbic.business.notification.create.NotificationContent
 import life.qbic.samplenotificator.cli.NotificatorCommandLineOptions
 import life.qbic.samplenotificator.components.CreateNotificationController
-import life.qbic.samplenotificator.components.CreateNotificationPresenter
+import life.qbic.samplenotificator.components.CreateNotificationConnector
+import life.qbic.samplenotificator.components.EmailGenerator
 import life.qbic.samplenotificator.datasource.database.DatabaseSession
 import life.qbic.samplenotificator.datasource.notification.create.FetchProjectDbConnector
 import life.qbic.samplenotificator.datasource.notification.create.FetchSubscriberDbConnector
@@ -20,10 +20,9 @@ import life.qbic.samplenotificator.datasource.notification.create.FetchSubscribe
 class DependencyManager {
 
     private Properties properties
-    private CreateNotificationPresenter createNotificationPresenter
+    private CreateNotificationConnector createNotificationConnector
     private CreateNotification createNotification
     private CreateNotificationController createNotificationController
-    private List<NotificationContent> notifications = []
 
     DependencyManager(NotificatorCommandLineOptions commandLineParameters){
         properties = getProperties(commandLineParameters.pathToConfig)
@@ -61,17 +60,13 @@ class DependencyManager {
     private void setupCreateNotification(){
         FetchSubscriberDbConnector subscriberDbConnector = new FetchSubscriberDbConnector(DatabaseSession.getInstance())
         FetchProjectDbConnector projectDbConnector = new FetchProjectDbConnector(DatabaseSession.getInstance())
-        createNotificationPresenter = new CreateNotificationPresenter(notifications)
-        createNotification = new CreateNotification(projectDbConnector, subscriberDbConnector, createNotificationPresenter)
+        EmailGenerator emailGenerator = new EmailGenerator()
+        createNotificationConnector = new CreateNotificationConnector(emailGenerator)
+        createNotification = new CreateNotification(projectDbConnector, subscriberDbConnector, createNotificationConnector)
         createNotificationController = new CreateNotificationController(createNotification)
     }
 
     CreateNotificationController getCreateNotificationController() {
         return createNotificationController
     }
-
-    CreateNotificationPresenter getCreateNotificationsPresenter() {
-        return createNotificationPresenter
-    }
-
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
@@ -73,10 +73,7 @@ class DependencyManager {
     }
 
     EmailGenerator getEmailGenerator(){
-        String HTMLTemplatePath = "notification-template/email-update-template.html"
-        emailGenerator = new EmailGenerator(HTMLTemplatePath, notifications)
+        emailGenerator = new EmailGenerator(notifications)
         return emailGenerator
     }
-
-
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
@@ -6,7 +6,6 @@ import life.qbic.business.notification.create.NotificationContent
 import life.qbic.samplenotificator.cli.NotificatorCommandLineOptions
 import life.qbic.samplenotificator.components.CreateNotificationController
 import life.qbic.samplenotificator.components.CreateNotificationPresenter
-import life.qbic.samplenotificator.components.EmailGenerator
 import life.qbic.samplenotificator.datasource.database.DatabaseSession
 import life.qbic.samplenotificator.datasource.notification.create.FetchProjectDbConnector
 import life.qbic.samplenotificator.datasource.notification.create.FetchSubscriberDbConnector

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/DependencyManager.groovy
@@ -25,7 +25,6 @@ class DependencyManager {
     private CreateNotification createNotification
     private CreateNotificationController createNotificationController
     private List<NotificationContent> notifications = []
-    private EmailGenerator emailGenerator
 
     DependencyManager(NotificatorCommandLineOptions commandLineParameters){
         properties = getProperties(commandLineParameters.pathToConfig)
@@ -72,8 +71,8 @@ class DependencyManager {
         return createNotificationController
     }
 
-    EmailGenerator getEmailGenerator(){
-        emailGenerator = new EmailGenerator(notifications)
-        return emailGenerator
+    CreateNotificationPresenter getCreateNotificationsPresenter() {
+        return createNotificationPresenter
     }
+
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/NotificatorApp.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/NotificatorApp.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Log4j2
 import life.qbic.cli.QBiCTool
 import life.qbic.samplenotificator.cli.NotificatorCommandLineOptions
 import life.qbic.samplenotificator.components.CreateNotificationController
+import life.qbic.samplenotificator.components.CreateNotificationPresenter
 import life.qbic.samplenotificator.components.EmailGenerator
 
 /**
@@ -25,7 +26,7 @@ class NotificatorApp extends QBiCTool<NotificatorCommandLineOptions>{
         DependencyManager dependencyManager = new DependencyManager(commandLineParameters)
         CreateNotificationController createNotificationController = dependencyManager.getCreateNotificationController()
         createNotificationController.createNotification(commandLineParameters.date)
-        EmailGenerator emailGenerator = dependencyManager.getEmailGenerator()
-        emailGenerator.sendEmails()
+        CreateNotificationPresenter createNotificationPresenter = dependencyManager.getCreateNotificationsPresenter()
+        createNotificationPresenter.sendEmailNotifications()
     }
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/NotificatorApp.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/NotificatorApp.groovy
@@ -4,8 +4,6 @@ import groovy.util.logging.Log4j2
 import life.qbic.cli.QBiCTool
 import life.qbic.samplenotificator.cli.NotificatorCommandLineOptions
 import life.qbic.samplenotificator.components.CreateNotificationController
-import life.qbic.samplenotificator.components.CreateNotificationPresenter
-import life.qbic.samplenotificator.components.EmailGenerator
 
 /**
  * <b>Builds up the app content and starts it</b>
@@ -22,11 +20,8 @@ class NotificatorApp extends QBiCTool<NotificatorCommandLineOptions>{
     @Override
     void execute() {
         NotificatorCommandLineOptions commandLineParameters = super.command as NotificatorCommandLineOptions
-
         DependencyManager dependencyManager = new DependencyManager(commandLineParameters)
         CreateNotificationController createNotificationController = dependencyManager.getCreateNotificationController()
         createNotificationController.createNotification(commandLineParameters.date)
-        CreateNotificationPresenter createNotificationPresenter = dependencyManager.getCreateNotificationsPresenter()
-        createNotificationPresenter.sendEmailNotifications()
     }
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationConnector.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationConnector.groovy
@@ -11,12 +11,12 @@ import life.qbic.business.notification.create.NotificationContent
  * @since: 1.0.0
  *
  */
-class CreateNotificationPresenter implements CreateNotificationOutput {
+class CreateNotificationConnector implements CreateNotificationOutput {
 
-    private List<NotificationContent> notifications
+    private EmailGenerator emailGenerator
 
-    CreateNotificationPresenter(EmailGenerator generator){
-        this.generator = generator
+    CreateNotificationConnector(EmailGenerator emailGenerator){
+        this.emailGenerator = emailGenerator
     }
 
     /**
@@ -27,9 +27,7 @@ class CreateNotificationPresenter implements CreateNotificationOutput {
      */
     @Override
     void createdNotifications(List<NotificationContent> notifications) {
-        notifications.each {
-            this.notifications.add(it)
-        }
+        sendEmailNotifications(notifications)
     }
 
     /**

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
@@ -44,8 +44,7 @@ class CreateNotificationPresenter implements CreateNotificationOutput {
         println(notification)
     }
 
-    void sendEmailNotifications(){
-        EmailGenerator emailGenerator = new EmailGenerator()
+    void sendEmailNotifications(List notifications){
         emailGenerator.sendEmails(notifications)
     }
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
@@ -15,8 +15,8 @@ class CreateNotificationPresenter implements CreateNotificationOutput {
 
     private List<NotificationContent> notifications
 
-    CreateNotificationPresenter(List<NotificationContent> notifications){
-        this.notifications = notifications
+    CreateNotificationPresenter(EmailGenerator generator){
+        this.generator = generator
     }
 
     /**

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/CreateNotificationPresenter.groovy
@@ -13,7 +13,7 @@ import life.qbic.business.notification.create.NotificationContent
  */
 class CreateNotificationPresenter implements CreateNotificationOutput {
 
-    List<NotificationContent> notifications
+    private List<NotificationContent> notifications
 
     CreateNotificationPresenter(List<NotificationContent> notifications){
         this.notifications = notifications
@@ -42,5 +42,10 @@ class CreateNotificationPresenter implements CreateNotificationOutput {
     void failNotification(String notification) {
         //ToDo failNotification should be passed into dedicated logging file on executing server
         println(notification)
+    }
+
+    void sendEmailNotifications(){
+        EmailGenerator emailGenerator = new EmailGenerator()
+        emailGenerator.sendEmails(notifications)
     }
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -34,7 +34,7 @@ class EmailGenerator {
     void sendEmails(List<NotificationContent> notificationContents) {
         notificationContents.each { NotificationContent notificationContent ->
             Document mailContent = fillEmailTemplate(notificationContent)
-            File emailHTMLFile = GroupEmailBodyAndHeaderIntoHTMLFile(filledEmailContent.html())
+            File emailHTMLFile = convertToEmail(filledEmailContent.html())
             send(emailHTMLFile, notificationContent.customerEmailAddress)
         }
     }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -33,7 +33,7 @@ class EmailGenerator {
      */
     void sendEmails(List<NotificationContent> notificationContents) {
         notificationContents.each { NotificationContent notificationContent ->
-            Document filledEmailContent = fillEmailContent(notificationContent)
+            Document mailContent = fillEmailTemplate(notificationContent)
             File emailHTMLFile = GroupEmailBodyAndHeaderIntoHTMLFile(filledEmailContent.html())
             send(emailHTMLFile, notificationContent.customerEmailAddress)
         }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -3,13 +3,16 @@ package life.qbic.samplenotificator.components
 import life.qbic.business.notification.create.NotificationContent
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
 
 
 /**
  * Class responsible for generating an sending an email from the provided notification and subscriber information
- *
+ * //ToDo Adapt documentation
  * EmailGenerator converts the notification created in the CreateNotification Use case into an emailBody
  * The contactInformation such as e.g. the emailAddress of the recipient is retrieved from the associated provided Subscriber
  * The email is then send via a commandline call to the mailutils tool(@link <a href=https://mailutils.org/>mailutils</a> via a ProcessBuilder
@@ -19,14 +22,32 @@ import java.util.concurrent.TimeUnit
  */
 class EmailGenerator {
 
-    private String subject = "Project Update"
+    /**
+     * Get the fixed email and email header template structure
+     */
+    private final InputStream EMAIL_HTML_HEADER_STREAM = EmailHTMLTemplate.class.getClassLoader().getResourceAsStream("notification-template/header.txt")
+    private final InputStream EMAIL_HTML_TEMPLATE_STREAM = EmailHTMLTemplate.class.getClassLoader().getResourceAsStream("notification-template/email-update-template.html")
+
+    /**
+     * Paths for temporary files used to prepare the final html file
+     */
+    private final Path tempDir
+    private final Path EMAIL_HTML_TEMPLATE_PATH
+    private final Path EMAIL_HTML_HEADER_PATH
+    private final Path EMAIL_HTML_CREATED_PATH
+
     NotificationContent notificationContent
-    private InputStream EMAIL_HTML_TEMPLATE_STREAM
     private EmailHTMLTemplate emailHTMLTemplate
-    private Document filledTemplate
+    private Document filledTemplateMessage
+    private File preparedEmailHTMLFile
 
     EmailGenerator(NotificationContent notificationContent) {
         this.notificationContent = notificationContent
+        this.tempDir = Files.createTempDirectory("EmailHTML")
+        this.EMAIL_HTML_HEADER_PATH = Paths.get(tempDir.toString(), "header.txt")
+        this.EMAIL_HTML_TEMPLATE_PATH = Paths.get(tempDir.toString(), "email-update-template.html")
+        this.EMAIL_HTML_CREATED_PATH = Paths.get(tempDir.toString(), "email.html")
+        importTemplateResources()
     }
 
     /**
@@ -34,35 +55,59 @@ class EmailGenerator {
      * containing the provided notifications to the provided subscribers
      */
     void initializeEmailSubmission() {
-        accessEmailTemplate()
         prepareHTMLEmail()
-        println(filledTemplate)
-        //ToDo Replace this with subscriber mail
-        //sendEmail("Steffen.greiner@uni-tuebingen.de", filledTemplate.html())
+        this.preparedEmailHTMLFile = writeHTMLContentToFile(filledTemplateMessage.html())
+        String emailRecipient = notificationContent.customerEmailAddress
+        sendEmail(preparedEmailHTMLFile, emailRecipient)
     }
 
-    private void accessEmailTemplate() {
-        this.EMAIL_HTML_TEMPLATE_STREAM = EmailHTMLTemplate.class.getClassLoader().getResourceAsStream("notification-template/email-update-template.html")
+    /**
+     * Prepare temporary files storing email message and email header templates
+     */
+    private void importTemplateResources() {
+        Files.copy(EMAIL_HTML_TEMPLATE_STREAM, EMAIL_HTML_TEMPLATE_PATH, StandardCopyOption.REPLACE_EXISTING)
+        Files.copy(EMAIL_HTML_HEADER_STREAM, EMAIL_HTML_HEADER_PATH, StandardCopyOption.REPLACE_EXISTING)
     }
 
+    /**
+     * Fill in template with subscriber and project information provided in the notificationContent
+     */
     private void prepareHTMLEmail() {
-        this.emailHTMLTemplate = new EmailHTMLTemplate(Jsoup.parse(EMAIL_HTML_TEMPLATE_STREAM, "UTF-8", ""))
-        this.filledTemplate = emailHTMLTemplate.fillTemplate(notificationContent)
+        this.emailHTMLTemplate = new EmailHTMLTemplate(Jsoup.parse(new File(EMAIL_HTML_TEMPLATE_PATH.toString()), "UTF-8"))
+        this.filledTemplateMessage = emailHTMLTemplate.fillTemplate(notificationContent)
     }
 
-    private void sendEmail(String emailRecipient, String notificationContent) {
-        def tempNotificationFile = new File('TempNotificationFile.html')
-        tempNotificationFile.write(notificationContent)
-        //ToDo Replace this with Sendmail and add custom header
-        ProcessBuilder builder = new ProcessBuilder("mail", "-s ${subject}", emailRecipient).redirectInput(tempNotificationFile)
+    /**
+     * Concatenates email header information and the actual email content into a singular file
+     *
+     * Method to create a file containing the email header information and the dynamically adapted email message.
+     * This is necessary since sendmail doesn't provide a dedicated command line switch to set the content-type of the message
+     */
+    private File writeHTMLContentToFile(String notificationContent){
+        File concatenatedHTMLFile = new File(EMAIL_HTML_CREATED_PATH.toString())
+        File emailHeaderFile = new File(EMAIL_HTML_HEADER_PATH.toString())
+        concatenatedHTMLFile.append(emailHeaderFile.bytes)
+        concatenatedHTMLFile.append(notificationContent)
+        return concatenatedHTMLFile
+    }
+
+    /**
+     * Sends the prepared html file to the email address provided in the notificationContent via sendmail
+     *
+     * The email is send via a commandline call to the mailutils sendmail tool(@link <a href=https://mailutils.org/>mailutils</a> via a ProcessBuilder
+     * //ToDo Finish documentation
+     *
+     */
+    //ToDo Move this into separate class
+    private int sendEmail(File emailHTMLFile, String emailRecipient) {
+        ProcessBuilder builder = new ProcessBuilder("sendmail", "-t", emailRecipient).redirectInput(emailHTMLFile)
         builder.redirectErrorStream(true)
         Process process = builder.start()
         process.waitFor(10, TimeUnit.SECONDS)
         //ToDo This has to be replaced with dedicated writing into a log on executing server
         process.getInputStream().eachLine {println(it)}
         //ToDo How should exit codes be handled with the cronjob? See https://mailutils.org/manual/html_section/mailutils.html for Exit Codes
-        println("ExitCode: " + process.exitValue())
-        tempNotificationFile.delete()
+        return process.exitValue()
     }
 
 }

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -34,7 +34,7 @@ class EmailGenerator {
     void sendEmails(List<NotificationContent> notificationContents) {
         notificationContents.each { NotificationContent notificationContent ->
             Document mailContent = fillEmailTemplate(notificationContent)
-            File emailHTMLFile = convertToEmail(filledEmailContent.html())
+            File emailHTMLFile = convertToEmail(mailContent.html())
             send(emailHTMLFile, notificationContent.customerEmailAddress)
         }
     }
@@ -52,7 +52,7 @@ class EmailGenerator {
     /**
      * Triggers the adaption of the emailTemplate to contain the information provided in the notificationContent
      */
-    private Document fillEmailContent(NotificationContent notificationContent) {
+    private Document fillEmailTemplate(NotificationContent notificationContent) {
         emailHTMLTemplate = new EmailHTMLTemplate(Jsoup.parse(emailNotificationTemplateSupplier.get(), "UTF-8", ""))
         Document filledEmailTemplate = emailHTMLTemplate.fillTemplate(notificationContent)
         return filledEmailTemplate
@@ -66,7 +66,7 @@ class EmailGenerator {
      * @param notificationContent String representation of the filled in HTML Email Template {@see notification-template/email-update-template.html}
      * @return concatenatedHTMLFile of the mailutils sendmail tool for detailed information see(@link <a href=https://www.cs.ait.ac.th/~on/O/oreilly/tcpip/sendmail/ch36_05.htm/>here</a>)
      */
-    private File GroupEmailBodyAndHeaderIntoHTMLFile(String notificationContent) {
+    private File convertToEmail(String notificationContent) {
         File concatenatedHTMLFile = File.createTempFile("HTMLEmail", ".html")
         concatenatedHTMLFile.append(emailHeaderTemplateSupplier.get())
         concatenatedHTMLFile.append(notificationContent)

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -11,11 +11,10 @@ import java.util.concurrent.TimeUnit
 
 
 /**
- * Class responsible for generating an sending an email from the provided notification and subscriber information
- * //ToDo Adapt documentation
- * EmailGenerator converts the notification created in the CreateNotification Use case into an emailBody
- * The contactInformation such as e.g. the emailAddress of the recipient is retrieved from the associated provided Subscriber
- * The email is then send via a commandline call to the mailutils tool(@link <a href=https://mailutils.org/>mailutils</a> via a ProcessBuilder
+ * Class responsible for generating an sending an email from the provided project and subscriber information
+ *
+ * EmailGenerator extracts the information provided in the NotificationContent DTO and fills it into a prepared template structure.
+ * Afterwards it sends the prepared email via a commandline call to the mailutils sendmail tool(@link <a href=https://mailutils.org/>mailutils</a> via a ProcessBuilder
  *
  * @since: 1.0.0
  *
@@ -80,8 +79,10 @@ class EmailGenerator {
     /**
      * Concatenates email header information and the actual email content into a singular file
      *
-     * Method to create a file containing the email header information and the dynamically adapted email message.
+     * Method to create a file containing the email header information{@see notification-template/header.txt} and the dynamically adapted email message.
      * This is necessary since sendmail doesn't provide a dedicated command line switch to set the content-type of the message
+     * @param notificationContent String representation of the filled in HTML Email Template {@see notification-template/email-update-template.html}
+     * @return concatenatedHTMLFile of the mailutils sendmail tool for detailed information see(@link <a href=https://www.cs.ait.ac.th/~on/O/oreilly/tcpip/sendmail/ch36_05.htm/>here</a>)
      */
     private File writeHTMLContentToFile(String notificationContent){
         File concatenatedHTMLFile = new File(EMAIL_HTML_CREATED_PATH.toString())
@@ -94,8 +95,12 @@ class EmailGenerator {
     /**
      * Sends the prepared html file to the email address provided in the notificationContent via sendmail
      *
-     * The email is send via a commandline call to the mailutils sendmail tool(@link <a href=https://mailutils.org/>mailutils</a> via a ProcessBuilder
-     * //ToDo Finish documentation
+     * The email is send via a commandline call to the mailutils sendmail tool(@link <a href=https://mailutils.org/>mailutils</a>) via a ProcessBuilder
+     * The "-t" switch allows sendmail to extract information about the email sender, subject and content-type from the email header.
+     *
+     * @param emailHTMLFile Prepared HTMLFile containing a dedicated emailHeader and the filled in emailTemplate
+     * @param emailRecipient String representation of the subscribers email address to which the email should be send
+     * @return ExitCode of the mailutils sendmail tool for detailed information see(@link <a href=https://www.cs.ait.ac.th/~on/O/oreilly/tcpip/sendmail/ch36_05.htm/>here</a>)
      *
      */
     //ToDo Move this into separate class

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -85,7 +85,6 @@ class EmailGenerator {
      * @return ExitCode of the mailutils sendmail tool for detailed information see(@link <a href=https://www.cs.ait.ac.th/~on/O/oreilly/tcpip/sendmail/ch36_05.htm/>here</a>)
      *
      */
-    //ToDo Move this into separate class
     private int send(File emailHTMLFile, String emailRecipient) {
             ProcessBuilder builder = new ProcessBuilder("sendmail", "-t", emailRecipient).redirectInput(emailHTMLFile)
             builder.redirectErrorStream(true)

--- a/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
+++ b/sample-notificator-app/src/main/groovy/life/qbic/samplenotificator/components/EmailGenerator.groovy
@@ -22,18 +22,16 @@ class EmailGenerator {
 
     String emailTemplatePath = "notification-template/email-update-template.html"
     String emailHeaderPath = "notification-template/header.txt"
-    List<NotificationContent> notificationContents
 
-    EmailGenerator(List<NotificationContent> notificationContents) {
+    EmailGenerator() {
         loadEmailTemplates()
-        this.notificationContents = notificationContents
     }
 
     /**
      * Generate an
      * containing the provided notifications to the provided subscribers
      */
-    void sendEmails() {
+    void sendEmails(List<NotificationContent> notificationContents) {
         notificationContents.each { NotificationContent notificationContent ->
             Document filledEmailContent = fillEmailContent(notificationContent)
             File emailHTMLFile = GroupEmailBodyAndHeaderIntoHTMLFile(filledEmailContent.html())

--- a/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
+++ b/sample-notificator-app/src/main/resources/notification-template/email-update-template.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>email-update-template</title>
-</head>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <title>Automated Email Update</title>
 <body>
 <div id="email-body">
   <div id="introduction">Dear <span id="person-information">Max Mustermann</span></div>

--- a/sample-notificator-app/src/main/resources/notification-template/header.txt
+++ b/sample-notificator-app/src/main/resources/notification-template/header.txt
@@ -1,0 +1,4 @@
+From: Developers@QBiC.com
+Subject: Sample Status Update
+Content-Type: text/html
+

--- a/sample-notificator-domain/pom.xml
+++ b/sample-notificator-domain/pom.xml
@@ -18,5 +18,4 @@
       <artifactId>data-model-lib</artifactId>
     </dependency>
   </dependencies>
-
 </project>


### PR DESCRIPTION
**Description of changes**
Introduces HTML based email sending via the sendmail linux command line utility. 
 
**Technical Information**
[Sendmail](https://linux.die.net/man/8/sendmail.sendmail) provides the possiblity to send HTML based emails via the linux commandline. 
However for this to work sendmail has to know what kind of content is provided as an input which is done via a dedicated headersection. 
Therefore the adapted and filled emailTemplate `email-update-template.html` has to be prepended with the header information provided in the `header.txt` file so sendmail can determine the content-type of the provided emailbody. 
