### PR TITLE
Empty sample notificator emails

### DIFF
--- a/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
+++ b/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
@@ -47,12 +47,13 @@ class CreateNotification implements CreateNotificationInput {
             projectsWithSamples.each { project ->
                 project.title = projectsWithTitles.get(project.code)
             }
-
             //add notifications with create notification method (directly adds notifications to list)
             projectsWithSamples.each { project ->
                 addNotificationForProject(project)
             }
-            output.createdNotifications(notifications)
+            if (!notifications.isEmpty()) {
+                output.createdNotifications(notifications)
+            }
         } catch (DatabaseQueryException databaseQueryException) {
             output.failNotification("An error occurred while trying to query the database during Notification creation for ${date}")
             log.error(databaseQueryException.message)
@@ -69,6 +70,7 @@ class CreateNotification implements CreateNotificationInput {
 
         int failedQCCount = filterSamplesByStatus(project.sampleCodes, "SAMPLE_QC_FAIL").size()
         int availableDataCount = filterSamplesByStatus(project.sampleCodes, "DATA_AVAILABLE").size()
+
         if (noRelevantStatusWasUpdated(failedQCCount, availableDataCount)) {
             log.info("Notification for project ${project.code} was not generated, since the sample status was not set to FAILED_QC or DATA_AVAILABLE")
             return

--- a/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
+++ b/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
@@ -51,9 +51,8 @@ class CreateNotification implements CreateNotificationInput {
             projectsWithSamples.each { project ->
                 addNotificationForProject(project)
             }
-            if (!notifications.isEmpty()) {
-                output.createdNotifications(notifications)
-            }
+            output.createdNotifications(notifications)
+
         } catch (DatabaseQueryException databaseQueryException) {
             output.failNotification("An error occurred while trying to query the database during Notification creation for ${date}")
             log.error(databaseQueryException.message)
@@ -71,7 +70,7 @@ class CreateNotification implements CreateNotificationInput {
         int failedQCCount = filterSamplesByStatus(project.sampleCodes, "SAMPLE_QC_FAIL").size()
         int availableDataCount = filterSamplesByStatus(project.sampleCodes, "DATA_AVAILABLE").size()
 
-        if (!isRelevantStatusUpdate(failedQCCount, availableDataCount)) {
+        if (!isRelevantStatusUpdated(failedQCCount, availableDataCount)) {
             log.info("Notification for project ${project.code} was not generated, since the sample status was not set to FAILED_QC or DATA_AVAILABLE")
             return
         }
@@ -111,7 +110,7 @@ class CreateNotification implements CreateNotificationInput {
         return projects
     }
 
-    private static boolean isRelevantStatusUpdate(int failedQCCount, int dataAvailableCount) {
+    private static boolean isRelevantStatusUpdated(int failedQCCount, int dataAvailableCount) {
         return (failedQCCount + dataAvailableCount) > 0
     }
 }

--- a/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
+++ b/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
@@ -111,7 +111,7 @@ class CreateNotification implements CreateNotificationInput {
         return projects
     }
 
-    private static boolean noRelevantStatusWasUpdated(int failedQCCount, int dataAvailableCount) {
-        return failedQCCount + dataAvailableCount == 0
+    private static boolean isRelevantStatusUpdate(int failedQCCount, int dataAvailableCount) {
+        return (failedQCCount + dataAvailableCount) > 0
     }
 }

--- a/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
+++ b/sample-notificator-domain/src/main/groovy/life/qbic/business/notification/create/CreateNotification.groovy
@@ -71,7 +71,7 @@ class CreateNotification implements CreateNotificationInput {
         int failedQCCount = filterSamplesByStatus(project.sampleCodes, "SAMPLE_QC_FAIL").size()
         int availableDataCount = filterSamplesByStatus(project.sampleCodes, "DATA_AVAILABLE").size()
 
-        if (noRelevantStatusWasUpdated(failedQCCount, availableDataCount)) {
+        if (!isRelevantStatusUpdate(failedQCCount, availableDataCount)) {
             log.info("Notification for project ${project.code} was not generated, since the sample status was not set to FAILED_QC or DATA_AVAILABLE")
             return
         }

--- a/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
+++ b/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
@@ -241,8 +241,8 @@ class CreateNotificationSpec extends Specification{
 
         Subscriber subscriber1 = new Subscriber("Awesome", "Customer", "awesome.customer@provider.com")
         List<Subscriber> subscribers = [subscriber1]
-        Map<String,String> projectsWithTitles = ["QMCDP": "",
-                                                 "QMAAP": ""]
+        Map<String,String> projectsWithTitles = ["QMCDP": "A test project title",
+                                                 "QMAAP": "Sequencing of bees"]
 
         and: "Datasource that returns various information needed"
         fetchSubscriberDataSource.getUpdatedSamplesForDay(_ as LocalDate) >> updatedSamples

--- a/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
+++ b/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
@@ -74,8 +74,11 @@ class CreateNotificationSpec extends Specification{
         when: "The CreateNotification use case is triggered"
         createNotification.createNotifications("2020-08-17")
 
-        then: "No notification is returned"
-        0* output.createdNotifications(_ as List<NotificationContent>)
+        then: "An Empty List with no notifications is returned"
+        1* output.createdNotifications(_ as List<NotificationContent>) >> {arguments ->
+            List<NotificationContent> notifications = arguments.get(0)
+            assert notifications.isEmpty()
+        }
         0* output.failNotification(_ as String)
     }
 
@@ -252,7 +255,10 @@ class CreateNotificationSpec extends Specification{
         when: "The CreateNotification use case is triggered"
         createNotification.createNotifications("2020-08-17")
 
-        then: "No notifications are returned"
-        0 * output.createdNotifications(_ as List<NotificationContent>)
+        then: "An empty list with no notifications is returned"
+        1* output.createdNotifications(_ as List<NotificationContent>) >> {arguments ->
+            List<NotificationContent> notifications = arguments.get(0)
+            assert notifications.isEmpty()
+        }
     }
 }

--- a/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
+++ b/sample-notificator-domain/src/test/groovy/life/qbic/business/subscription/CreateNotificationSpec.groovy
@@ -227,7 +227,7 @@ class CreateNotificationSpec extends Specification{
         CreateNotificationOutput output = Mock()
         CreateNotification createNotification = new CreateNotification(projectDataSource,fetchSubscriberDataSource, output)
 
-        and: "a dummy Subscriber list and a map containing Samples with their updated Sample status"
+        and: "a dummy subscriber list and a map containing samples with their updated sample status that should not trigger an notifaction email"
         Map<String, Status> updatedSamples = ["QMCDP007A3":Status.SAMPLE_RECEIVED,
                                               "QMCDP007A2":Status.SEQUENCING,
                                               "QMCDP007A1":Status.SAMPLE_QC_PASS,


### PR DESCRIPTION
**What has been changed** 
Added checks for the `createNotification` class to only create notifications if a sample was updated to `SAMPLE_QC_FAILED` or `DATA_AVAILABLE`. 
If no samples of a project were updated to that status then the createNotification process stops and no email will be sent out. 
Additionally add tests for all irrelevant sample statuses. 

**Why it has been changed** 
Addresses [DM-116](https://qbicsoftware.atlassian.net/jira/software/c/projects/DM/boards/4?modal=detail&selectedIssue=DM-116), which is the result of creating notifications and passing them to the `Emailgenerator` as soon as an entry has been made for a project in the `notification` table irrelevant of the set status. 
The template will then remove the lines for the statuses that have not been set leading to an empty email text concerning the sample status

**How To Test** 
You can trigger the sample-notificator-cli as follows ` java -jar sample-notificator-app-1.1.0-SNAPSHOT-jar-with-dependencies.jar -c <PATH-TO-CONFIG> -d 2021-11-25`
And check the log. It should not send an email since no relevant status was set